### PR TITLE
Enable permissionless vault creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ This Accountant provides the exchange rate information needed by the Teller to a
 ### VaultFactory
 The repository now includes a `VaultFactory` contract that lets anyone deploy a Boring Vault with custom ERC-20 assets. It deploys a vault, manager, teller and accountant using a new `RolesAuthority` so deposits work immediately.
 
+### AllocationRouter
+An optional `AllocationRouter` contract channels USDC deposits into arbitrary ERC-20 compositions using a swapper. It supports rebalancing when allocation percentages change.
+
 
 ## Audits
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ This Accountant provides the exchange rate information needed by the Teller to a
    1. _Rate Limiting_: Exchange rates can only be updated so often.
    2. _Bound Limiting_: Exchange rates must fall within a certain bound created using the previous exchange rate on chain.
    3. These two restrictions greatly limit how fast the exchange rate can change, and if either of them are violated, the Accountant enters a `paused` state which stops all BoringVault deposits and withdraws, and new exchange rate updates, until permissioned accounts unpause it.
+### VaultFactory
+The repository now includes a `VaultFactory` contract that lets anyone deploy a Boring Vault with custom ERC-20 assets. It deploys a vault, manager, teller and accountant using a new `RolesAuthority` so deposits work immediately.
+
 
 ## Audits
 

--- a/src/factory/AllocationRouter.sol
+++ b/src/factory/AllocationRouter.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {Auth, Authority} from "@solmate/auth/Auth.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {ISwapper} from "../interfaces/ISwapper.sol";
+import {TellerWithMultiAssetSupport} from "../base/Roles/TellerWithMultiAssetSupport.sol";
+import {BoringVault} from "../base/BoringVault.sol";
+
+contract AllocationRouter is Auth {
+    struct Allocation {
+        ERC20 asset;
+        uint16 bps;
+    }
+
+    ISwapper public immutable swapper;
+    TellerWithMultiAssetSupport public immutable teller;
+    ERC20 public immutable baseAsset;
+
+    Allocation[] public allocations;
+
+    event AllocationsUpdated();
+    event DepositRouted(address indexed user, uint256 amountIn, uint256 sharesOut);
+
+    constructor(
+        address owner,
+        ISwapper _swapper,
+        TellerWithMultiAssetSupport _teller,
+        ERC20 _baseAsset,
+        Allocation[] memory initialAllocations
+    ) Auth(owner, Authority(address(0))) {
+        swapper = _swapper;
+        teller = _teller;
+        baseAsset = _baseAsset;
+        _setAllocations(initialAllocations);
+    }
+
+    function setAllocations(Allocation[] calldata newAllocs) external requiresAuth {
+        _setAllocations(newAllocs);
+    }
+
+    function _setAllocations(Allocation[] memory newAllocs) internal {
+        delete allocations;
+        uint256 total;
+        uint256 len = newAllocs.length;
+        for (uint256 i; i < len; ++i) {
+            allocations.push(newAllocs[i]);
+            total += newAllocs[i].bps;
+        }
+        require(total == 1e4, "bad-bps");
+        emit AllocationsUpdated();
+    }
+
+    function deposit(uint256 amount, uint256 minShares) external returns (uint256 sharesOut) {
+        baseAsset.transferFrom(msg.sender, address(this), amount);
+        sharesOut = _allocate(amount);
+        require(sharesOut >= minShares, "min-shares");
+        BoringVault(address(teller.vault())).transfer(msg.sender, sharesOut);
+        emit DepositRouted(msg.sender, amount, sharesOut);
+    }
+
+    function _allocate(uint256 amount) internal returns (uint256 sharesOut) {
+        uint256 len = allocations.length;
+        for (uint256 i; i < len; ++i) {
+            Allocation memory al = allocations[i];
+            uint256 portion = amount * al.bps / 1e4;
+            uint256 received;
+            if (al.asset != baseAsset) {
+                baseAsset.approve(address(swapper), portion);
+                received = swapper.swap(baseAsset, al.asset, portion, address(this));
+            } else {
+                received = portion;
+            }
+            al.asset.approve(address(teller.vault()), received);
+            sharesOut += teller.deposit(al.asset, received, 0);
+        }
+    }
+
+    function rebalance() external requiresAuth {
+        BoringVault vault = BoringVault(address(teller.vault()));
+        uint256 len = allocations.length;
+        uint256 total;
+        for (uint256 i; i < len; ++i) {
+            total += allocations[i].asset.balanceOf(address(vault));
+        }
+        for (uint256 i; i < len; ++i) {
+            Allocation memory al = allocations[i];
+            uint256 target = total * al.bps / 1e4;
+            uint256 current = al.asset.balanceOf(address(vault));
+            if (current > target) {
+                uint256 excess = current - target;
+                // approve swapper with tokens in vault
+                address[] memory targets = new address[](2);
+                bytes[] memory datas = new bytes[](2);
+                uint256[] memory values = new uint256[](2);
+                targets[0] = address(al.asset);
+                datas[0] = abi.encodeWithSelector(ERC20.approve.selector, address(swapper), excess);
+                targets[1] = address(swapper);
+                datas[1] = abi.encodeWithSelector(ISwapper.swap.selector, al.asset, baseAsset, excess, address(vault));
+                vault.manage(targets, datas, values);
+            } else if (current < target) {
+                uint256 deficit = target - current;
+                address[] memory targets = new address[](2);
+                bytes[] memory datas = new bytes[](2);
+                uint256[] memory values = new uint256[](2);
+                targets[0] = address(baseAsset);
+                datas[0] = abi.encodeWithSelector(ERC20.approve.selector, address(swapper), deficit);
+                targets[1] = address(swapper);
+                datas[1] = abi.encodeWithSelector(ISwapper.swap.selector, baseAsset, al.asset, deficit, address(vault));
+                vault.manage(targets, datas, values);
+            }
+        }
+    }
+}
+

--- a/src/factory/VaultFactory.sol
+++ b/src/factory/VaultFactory.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {BoringVault} from "../base/BoringVault.sol";
+import {ManagerWithMerkleVerification} from "../base/Roles/ManagerWithMerkleVerification.sol";
+import {TellerWithMultiAssetSupport} from "../base/Roles/TellerWithMultiAssetSupport.sol";
+import {AccountantWithRateProviders} from "../base/Roles/AccountantWithRateProviders.sol";
+import {RolesAuthority, Authority} from "@solmate/auth/authorities/RolesAuthority.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import "../helper/Constants.sol";
+
+/**
+ * @title VaultFactory
+ * @notice Allows anyone to deploy a minimal Boring Vault setup with custom assets.
+ */
+contract VaultFactory {
+    event VaultCreated(address vault, address manager, address teller, address accountant, address authority);
+
+    function createVault(
+        string calldata name,
+        string calldata symbol,
+        ERC20 base,
+        address balancerVault,
+        address payout,
+        ERC20[] calldata assets,
+        bool[] calldata isPeggedToBase,
+        address[] calldata rateProviders
+    ) external returns (address vaultAddr, address managerAddr, address tellerAddr, address accountantAddr, address authorityAddr) {
+        require(assets.length == isPeggedToBase.length && assets.length == rateProviders.length, "length mismatch");
+
+        // Deploy core contracts owned by the caller
+        BoringVault vault = new BoringVault(msg.sender, name, symbol, base.decimals());
+        AccountantWithRateProviders accountant = new AccountantWithRateProviders(
+            msg.sender,
+            address(vault),
+            payout,
+            uint96(10 ** base.decimals()),
+            address(base),
+            1.001e4,
+            0.999e4,
+            3600,
+            0
+        );
+        TellerWithMultiAssetSupport teller = new TellerWithMultiAssetSupport(msg.sender, address(vault), address(accountant));
+        ManagerWithMerkleVerification manager = new ManagerWithMerkleVerification(msg.sender, address(vault), balancerVault);
+        RolesAuthority authority = new RolesAuthority(msg.sender, Authority(address(0)));
+
+        vault.setAuthority(authority);
+        accountant.setAuthority(authority);
+        teller.setAuthority(authority);
+        manager.setAuthority(authority);
+
+        // Configure role capabilities
+        authority.setRoleCapability(MANAGER_ROLE, address(vault), bytes4(keccak256("manage(address,bytes,uint256)")), true);
+        authority.setRoleCapability(MANAGER_ROLE, address(vault), bytes4(keccak256("manage(address[],bytes[],uint256[])")), true);
+        authority.setRoleCapability(TELLER_ROLE, address(vault), BoringVault.enter.selector, true);
+        authority.setRoleCapability(TELLER_ROLE, address(vault), BoringVault.exit.selector, true);
+        authority.setRoleCapability(UPDATE_EXCHANGE_RATE_ROLE, address(accountant), AccountantWithRateProviders.updateExchangeRate.selector, true);
+        authority.setPublicCapability(address(teller), TellerWithMultiAssetSupport.deposit.selector, true);
+
+        // Assign roles
+        authority.setUserRole(msg.sender, STRATEGIST_ROLE, true);
+        authority.setUserRole(address(manager), MANAGER_ROLE, true);
+        authority.setUserRole(address(teller), TELLER_ROLE, true);
+        authority.setUserRole(msg.sender, UPDATE_EXCHANGE_RATE_ROLE, true);
+        authority.setUserRole(msg.sender, PAUSER_ROLE, true);
+
+        // Add supported assets and rate providers
+        teller.addAsset(base);
+        accountant.setRateProviderData(base, true, address(0));
+        for (uint256 i; i < assets.length; ++i) {
+            teller.addAsset(assets[i]);
+            accountant.setRateProviderData(assets[i], isPeggedToBase[i], rateProviders[i]);
+        }
+
+        emit VaultCreated(address(vault), address(manager), address(teller), address(accountant), address(authority));
+
+        return (address(vault), address(manager), address(teller), address(accountant), address(authority));
+    }
+}

--- a/src/interfaces/ISwapper.sol
+++ b/src/interfaces/ISwapper.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+
+interface ISwapper {
+    function swap(ERC20 tokenIn, ERC20 tokenOut, uint256 amountIn, address recipient) external returns (uint256 amountOut);
+}

--- a/test/factory/AllocationRouter.t.sol
+++ b/test/factory/AllocationRouter.t.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {Test} from "@forge-std/Test.sol";
+import {AllocationRouter} from "src/factory/AllocationRouter.sol";
+import {VaultFactory} from "src/factory/VaultFactory.sol";
+import {MockERC20} from "test/mocks/MockERC20.sol";
+import {MockSwapper} from "test/mocks/MockSwapper.sol";
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+import {BoringVault} from "src/base/BoringVault.sol";
+
+contract AllocationRouterTest is Test {
+    VaultFactory factory;
+    MockERC20 base;
+    MockERC20 asset1;
+    MockERC20 asset2;
+    MockSwapper swapper;
+
+    function setUp() external {
+        factory = new VaultFactory();
+        base = new MockERC20("Base", "BASE", 18);
+        asset1 = new MockERC20("Asset1", "A1", 18);
+        asset2 = new MockERC20("Asset2", "A2", 18);
+        swapper = new MockSwapper();
+        base.mint(address(this), 100 ether);
+    }
+
+    function testDepositAndRebalance() external {
+        BoringVault vault;
+        TellerWithMultiAssetSupport teller;
+        {
+            address balancer = address(0);
+            address payout = address(0x1234);
+            MockERC20[] memory assets = new MockERC20[](2);
+            assets[0] = asset1;
+            assets[1] = asset2;
+            bool[] memory pegged = new bool[](2);
+            pegged[0] = true;
+            pegged[1] = true;
+            address[] memory providers = new address[](2);
+            providers[0] = address(0);
+            providers[1] = address(0);
+            (address v, , address t, , ) = factory.createVault(
+                "MyVault",
+                "MV",
+                base,
+                balancer,
+                payout,
+                assets,
+                pegged,
+                providers
+            );
+            vault = BoringVault(v);
+            teller = TellerWithMultiAssetSupport(t);
+        }
+
+        AllocationRouter.Allocation[] memory allocs = new AllocationRouter.Allocation[](2);
+        allocs[0] = AllocationRouter.Allocation({asset: asset1, bps: 5000});
+        allocs[1] = AllocationRouter.Allocation({asset: asset2, bps: 5000});
+        AllocationRouter router = new AllocationRouter(address(this), swapper, teller, base, allocs);
+
+        base.approve(address(router), 10 ether);
+        uint256 shares = router.deposit(10 ether, 0);
+        assertEq(shares, 10 ether);
+    }
+}

--- a/test/factory/VaultFactory.t.sol
+++ b/test/factory/VaultFactory.t.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {Test} from "@forge-std/Test.sol";
+import {VaultFactory} from "src/factory/VaultFactory.sol";
+import {MockERC20} from "test/mocks/MockERC20.sol";
+import {TellerWithMultiAssetSupport} from "src/base/Roles/TellerWithMultiAssetSupport.sol";
+import {BoringVault} from "src/base/BoringVault.sol";
+
+contract VaultFactoryTest is Test {
+    VaultFactory factory;
+    MockERC20 base;
+    MockERC20 asset;
+
+    function setUp() external {
+        factory = new VaultFactory();
+        base = new MockERC20("Base", "BASE", 18);
+        asset = new MockERC20("Asset", "ASSET", 18);
+        base.mint(address(this), 10 ether);
+        asset.mint(address(this), 5 ether);
+    }
+
+    function testCreateAndDeposit() external {
+        BoringVault vault;
+        TellerWithMultiAssetSupport teller;
+        {
+            address balancer = address(0);
+            address payout = address(0x1234);
+            MockERC20[] memory assets = new MockERC20[](1);
+            assets[0] = asset;
+            bool[] memory pegged = new bool[](1);
+            pegged[0] = true;
+            address[] memory providers = new address[](1);
+            providers[0] = address(0);
+            (address v, , address t, , ) = factory.createVault(
+                "MyVault",
+                "MV",
+                base,
+                balancer,
+                payout,
+                assets,
+                pegged,
+                providers
+            );
+            vault = BoringVault(v);
+            teller = TellerWithMultiAssetSupport(t);
+        }
+
+        base.approve(address(vault), 10 ether);
+        uint256 shares0 = teller.deposit(base, 10 ether, 0);
+        assertEq(shares0, 10 ether);
+
+        asset.approve(address(vault), 5 ether);
+        uint256 shares1 = teller.deposit(asset, 5 ether, 0);
+        assertEq(shares1, 5 ether);
+    }
+}

--- a/test/mocks/MockERC20.sol
+++ b/test/mocks/MockERC20.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.21;
+
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+
+contract MockERC20 is ERC20 {
+    constructor(string memory name, string memory symbol, uint8 decimals) ERC20(name, symbol, decimals) {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/test/mocks/MockSwapper.sol
+++ b/test/mocks/MockSwapper.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import {ISwapper} from "src/interfaces/ISwapper.sol";
+import {ERC20} from "@solmate/tokens/ERC20.sol";
+import {MockERC20} from "test/mocks/MockERC20.sol";
+
+contract MockSwapper is ISwapper {
+    function swap(ERC20 tokenIn, ERC20 tokenOut, uint256 amountIn, address recipient) external returns (uint256) {
+        tokenIn.transferFrom(msg.sender, address(this), amountIn);
+        MockERC20(address(tokenOut)).mint(recipient, amountIn);
+        return amountIn;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `VaultFactory` contract for easy user deployments
- add mocks and tests for factory behavior
- document new factory in the README

## Testing
- `forge fmt` *(fails: command not found)*
- `forge test` *(not run: Foundry unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68488dc115288328bdc5303b3a5e95f2