### PR TITLE
Add DailyRebalancer micro-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,15 @@ This Accountant provides the exchange rate information needed by the Teller to a
 2. Exchange rates written on chain are rate limited, and bound limited.
    1. _Rate Limiting_: Exchange rates can only be updated so often.
    2. _Bound Limiting_: Exchange rates must fall within a certain bound created using the previous exchange rate on chain.
-   3. These two restrictions greatly limit how fast the exchange rate can change, and if either of them are violated, the Accountant enters a `paused` state which stops all BoringVault deposits and withdraws, and new exchange rate updates, until permissioned accounts unpause it.
+3. These two restrictions greatly limit how fast the exchange rate can change, and if either of them are violated, the Accountant enters a `paused` state which stops all BoringVault deposits and withdraws, and new exchange rate updates, until permissioned accounts unpause it.
+
+### DailyRebalancer
+
+`DailyRebalancer` extends `DexAggregatorUManager` and holds a list of assets with
+their respective allocation weights. Calling `rebalance` swaps the vault's
+pending deposit asset into each configured asset using 1inch according to the
+configured weights. This function expects the same merkle proofs and decoder
+arrays used by other uManagers and can be triggered offchain on a schedule.
 
 ## Audits
 

--- a/src/rebalancers/DailyRebalancer.sol
+++ b/src/rebalancers/DailyRebalancer.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.21;
+
+import { DexAggregatorUManager, ERC20 } from "src/micro-managers/DexAggregatorUManager.sol";
+
+contract DailyRebalancer is DexAggregatorUManager {
+    struct Allocation {
+        ERC20 asset;
+        uint16 weight; // scaled by 1e4
+    }
+
+    Allocation[] public allocations;
+    ERC20 public immutable depositAsset;
+    uint16 public constant WEIGHT_SCALE = 1e4;
+
+    event AllocationsUpdated();
+    event Rebalanced(uint256 depositAmount);
+
+    constructor(
+        address _owner,
+        address _manager,
+        address _vault,
+        address _router,
+        address _priceRouter,
+        ERC20 _depositAsset
+    )
+        DexAggregatorUManager(_owner, _manager, _vault, _router, _priceRouter)
+    {
+        depositAsset = _depositAsset;
+    }
+
+    function setAllocations(ERC20[] calldata assets, uint16[] calldata weights) external requiresAuth {
+        require(assets.length == weights.length, "len mismatch");
+        delete allocations;
+        uint256 total;
+        for (uint256 i; i < assets.length; ++i) {
+            allocations.push(Allocation({asset: assets[i], weight: weights[i]}));
+            total += weights[i];
+        }
+        require(total == WEIGHT_SCALE, "bad weights");
+        emit AllocationsUpdated();
+    }
+
+    function rebalance(
+        bytes32[][][] calldata manageProofs,
+        address[][] calldata decodersAndSanitizers,
+        bytes[] calldata swapData
+    ) external requiresAuth enforceRateLimit {
+        uint256 len = allocations.length;
+        require(
+            len == manageProofs.length && len == decodersAndSanitizers.length && len == swapData.length,
+            "bad len"
+        );
+
+        uint256 balance = depositAsset.balanceOf(boringVault);
+        for (uint256 i; i < len; ++i) {
+            uint256 amount = (balance * allocations[i].weight) / WEIGHT_SCALE;
+            if (amount == 0) continue;
+            swapWith1Inch(manageProofs[i], decodersAndSanitizers[i], depositAsset, amount, allocations[i].asset, swapData[i]);
+        }
+        emit Rebalanced(balance);
+    }
+}


### PR DESCRIPTION
## Summary
- add `DailyRebalancer` contract for automated allocation of deposit assets
- document the new rebalancer in the README

## Testing
- `npm run solhint` *(fails: `solhint` not found)*
- `npm run coverage` *(fails: `./coverage.sh: not found`)*
- `npm run prettier`
- `forge test` *(fails: `forge: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684953305b248328b1d7c591f0bbabdc